### PR TITLE
Made the slash in the webhookUrl optional

### DIFF
--- a/src/mollie/mollie.php
+++ b/src/mollie/mollie.php
@@ -88,7 +88,7 @@ function mollie_link($params, $method = Mollie_API_Object_Method::IDEAL) {
                 'method' => $method,
                 'description' => $params['description'],
                 'redirectUrl' => $params['returnurl'] . '&check_payment=' . $transactionId,
-                'webhookUrl' => $params['systemurl'] . '/modules/gateways/mollie/callback.php',
+                'webhookUrl' => $params['systemurl'] . (substr($params['systemurl'], -1) != '/' ? '/' : '') . 'modules/gateways/mollie/callback.php',
                 'metadata' => array(
                     'invoice_id' => $params['invoiceid'],
                 ),


### PR DESCRIPTION
A double slash in the webhookUrl causes issues (301 redirect and loosing POST vars in the callback). This occurs when the systemurl ends with a slash.
This change checks for this slash and only adds one if needed.
Note: not yet 100% tested